### PR TITLE
Set buildid to empty string for reproducible builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -buildid='
   goos:
     - freebsd
     - windows


### PR DESCRIPTION
When trying to verify the checksum of the binaries published in the terraform registry, I noticed that the buildid is the only difference.

Based on https://github.com/golang/go/issues/33772 it sounds like this is because the buildid hashes the build path even if -trimpath is used. I could not find the build path used. Sharing the build path could be another option.